### PR TITLE
VBID-5082 stack trace when restarting trafficking ui

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -91,7 +91,12 @@ module.exports = (projectConfig={}) ->
     runSequence('clean', ['src', 'static', 'style'])
 
 
-  gulp.task 'watch:serve', ['watch', 'serve']
+  gulp.task 'serve', ->
+    runSequence('clean', ['src', 'static', 'style'], ['_serve'])
+
+
+  gulp.task 'watch:serve', ->
+    runSequence('clean', ['src', 'static', 'style'], ['watch', '_serve'])
 
 
   build = ->
@@ -124,7 +129,7 @@ module.exports = (projectConfig={}) ->
       .pipe(gulp.dest(config.dest))
 
 
-  gulp.task 'serve', ['build'], ->
+  gulp.task '_serve', ->
     lr  = livereload()
     app = connect()
     app


### PR DESCRIPTION
Fix race condition in which watch & serve were being called concurrently with clean (as part of build).
