### PR TITLE
QUICKFIX: Run watch concurrently with build so it actually watches

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -92,11 +92,11 @@ module.exports = (projectConfig={}) ->
 
 
   gulp.task 'serve', ->
-    runSequence('clean', ['src', 'static', 'style'], ['_serve'])
+    runSequence('clean', ['src', 'static', 'style'], '_serve')
 
 
   gulp.task 'watch:serve', ->
-    runSequence('clean', ['src', 'static', 'style'], ['watch', '_serve'])
+    runSequence('clean', ['src', 'static', 'style', 'watch'], '_serve')
 
 
   build = ->


### PR DESCRIPTION
When watch is started strictly after build, it does not seem to work. When it runs concurrently with the build steps, it works.
